### PR TITLE
AWS account controller: user namespace and secrets

### DIFF
--- a/api/v1/awsaccount_types.go
+++ b/api/v1/awsaccount_types.go
@@ -49,6 +49,9 @@ type AwsAccountStatus struct {
 
 	// +optional
 	UserGroups []string `json:"userGroups"`
+
+	// +optional
+	NamespaceCreated bool `json:"namespaceCreated"`
 }
 
 //+kubebuilder:object:root=true

--- a/config/crd/bases/kuadra.kuadrant.io_awsaccounts.yaml
+++ b/config/crd/bases/kuadra.kuadrant.io_awsaccounts.yaml
@@ -57,6 +57,8 @@ spec:
                 type: boolean
               loginProfileCreated:
                 type: boolean
+              namespaceCreated:
+                type: boolean
               userCreated:
                 type: boolean
               userGroups:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,6 +18,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - kuadra.kuadrant.io
   resources:
   - awsaccounts

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,18 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - kuadra.kuadrant.io
   resources:
   - awsaccounts


### PR DESCRIPTION
- Create namespace for user
- Create secret `aws-login` in user's ns containing user name and one-time password
- Create secret `aws-credentials` in user's ns containing `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`