### PR TITLE
Fix: Check user exists before listing groups

### DIFF
--- a/internal/controller/awsaccount_controller.go
+++ b/internal/controller/awsaccount_controller.go
@@ -288,6 +288,14 @@ func (r *AwsAccountReconciler) deleteNamespace(ctx context.Context, namespace st
 }
 
 func (r *AwsAccountReconciler) deleteIamUser(ctx context.Context, userName string) error {
+	userExists, err := r.IamWrapper.IsExistingUser(ctx, userName)
+	if err != nil {
+		return err
+	}
+	if !userExists {
+		return nil
+	}
+
 	groups, err := r.IamWrapper.ListGroupsForUser(ctx, userName)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes error loop which occurred if IAM user had been deleted outside of Kuadra - (AWS console, etc.)