### PR TITLE
Removed imagePullPolicy and added namespace to local config

### DIFF
--- a/config/local/kustomization.yaml
+++ b/config/local/kustomization.yaml
@@ -1,3 +1,5 @@
+namespace: kuadra-system
+
 resources:
 - ../default
 

--- a/config/local/manager_config_patch.yaml
+++ b/config/local/manager_config_patch.yaml
@@ -8,4 +8,3 @@ spec:
     spec:
       containers:
       - name: manager
-        imagePullPolicy: Never


### PR DESCRIPTION
### Problem:
- The imagePullPolicy was preventing the pods from pulling the image from the user's specified repository, causing a ImageNeverPull error. 
- The generated secret from aws-credentials.env was not able to be accessed by pods in the kuadra-system namespace as the secret was generated in the default namespace, causing a CreateContainerConfig error.

### Solution:
- Removing imagePullPolicy from `config/local/manager_config_patch.yaml` , allowing the pods to pull the image from the user's specified repository.
- Adding the `kuadra-system` namespace to `config/local/kustomisation.yaml` , ensuring the secret is accessible within the `kuadra-system` namespace for pods which allows the pods to run.

### How to reproduce the error (main branch):
```bash
# Set up and run the cluster
kind create cluster
make install
IMG=quay.io/<namespace>/kuadra:v1 make docker-build docker-push deploy-local
# Check for imagePullPolicy error
kubectl -n kuadra-system get pods
# Remove imageNeverPull from deployment config
kubectl -n kuadra-system edit deploy kuadra-controller-manager
# Once removed, check for CreateContainerConfig error
kubectl -n kuadra-system get pods
kind delete cluster
```
### How to confirm error is resolved (on deploy-local branch):
```bash
# Set up and run the cluster
kind create cluster
make install
IMG=quay.io/<namespace>/kuadra:v1 make docker-build docker-push deploy-local
# Check for imagePullPolicy error
kubectl -n kuadra-system get pods
```