### PR TITLE
Using Go version from go.mod in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,10 @@ jobs:
       - uses: actions/checkout@v4
       
       - name: setting up go
-      - uses: actions/setup-go@v5
+        uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      
       - run: go version
 
       - name: Run suite

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
   test_suite:
     name: Test Suite
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,19 +23,13 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: getting go version from go.mod
-        id: go-version
-        run: |
-          GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
-          echo "version=$GO_VERSION" >> $GITHUB_OUTPUT
-
+      - uses: actions/checkout@v4
+      
       - name: setting up go
-        uses: actions/setup-go@v2
+      - uses: actions/setup-go@v5
         with:
-          go-version: ${{ steps.go-version.outputs.version }}
+          go-version-file: 'go.mod'
+      - run: go version
 
       - name: Run suite
-        run: |
-          make test
+        run: make test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,9 +24,18 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+
+      - name: getting go version from go.mod
+        id: go-version
+        run: |
+          GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
+          echo "version=$GO_VERSION" >> $GITHUB_OUTPUT
+
+      - name: setting up go
+        uses: actions/setup-go@v2
         with:
-          go-version: v1.20
+          go-version: ${{ steps.go-version.outputs.version }}
+
       - name: Run suite
         run: |
           make test


### PR DESCRIPTION
I configured your ci workflow to use the go version from your go.mod file. also I encountered an error which says github doesn't support ubuntu 20 in workflows so I changed it to ubuntu latest and tested it with success.

I saw you have other repositories with same issue. let me know if you want them changed this way too :) 